### PR TITLE
Fix workflow trigger and permalink deprecation warning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy Hugo site to GitHub Pages
 on:
   push:
     branches:
-      - redesign-2026   # switch to master after merging
+      - master
   workflow_dispatch:    # allows manual trigger from GitHub UI
 
 # Allow only one deployment at a time

--- a/config.toml
+++ b/config.toml
@@ -25,8 +25,8 @@ googleAnalytics = "UA-19970008-2"
   Content = "Writing about tai chi and code."
 
 [permalinks]
-  taichi = "/taichi/:filename"
-  code = "/code/:filename"
+  taichi = "/taichi/:contentbasename"
+  code = "/code/:contentbasename"
 
 [[menu.main]]
   name = "Tai Chi"


### PR DESCRIPTION
- deploy.yml: trigger on master instead of redesign-2026
- config.toml: :filename → :contentbasename (Hugo 0.144+ requirement) URLs are identical, just using the non-deprecated token